### PR TITLE
Add iOS support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,44 @@ jobs:
           key: konan-{{ arch }}-{{ checksum "/tmp/gradle_cache_seed" }}
           paths:
             - ~/.konan
+  ios-test:
+    macos:
+      xcode: 26.4.0
+    # macOS minutes bill at a premium; m4pro.medium is the smallest current Apple silicon class. Adjust the Xcode
+    # version and resource_class to whatever your CircleCI plan offers.
+    resource_class: m4pro.medium
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore Konan and Gradle caches
+          keys:
+            - konan-gradle-{{ arch }}-{{ checksum "gradle/libs.versions.toml" }}
+      - run:
+          # Apple silicon runner, so exercise the arm64 simulator target.
+          name: Run iOS simulator tests
+          command: ./gradlew iosSimulatorArm64Test --no-daemon
+      - save_cache:
+          name: Save Konan and Gradle caches
+          key: konan-gradle-{{ arch }}-{{ checksum "gradle/libs.versions.toml" }}
+          paths:
+            - ~/.konan
+            - ~/.gradle/caches
 workflows:
   build:
     jobs:
+      - ios-test:
+          # Gates the build/publish job below; must share its tag filter so releases are scheduled on tags.
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore:
+                - gh-pages
       - build:
           context: Sonatype
+          # Block build and publish until the iOS simulator tests pass.
+          requires:
+            - ios-test
           filters:
             tags:
               only: /.*/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This library was built as a practical experiment with Kotlin Multiplatform and s
 Arbor follows a very similar usage pattern to [Timber](https://github.com/jakewharton/timber). Key differences exist in feature support and terminology which was done purely because I had a thesaurus laying around.
 
 ##### Sow Your Seedling
-Seedlings are platform specific logging implementations such as using `Logcat` in Android and `println` in JavaScript.
+Seedlings are platform specific logging implementations such as using `Logcat` in Android, `NSLog` in iOS, and `println` in JavaScript.
 
 Android
 ```kotlin
@@ -23,6 +23,11 @@ Arbor.sow(Seedling())
 ```
 
 JVM
+```kotlin
+Arbor.sow(Seedling())
+```
+
+iOS
 ```kotlin
 Arbor.sow(Seedling())
 ```
@@ -66,10 +71,15 @@ Arbor is a Kotlin Multiplatform project support multiple target platforms.
 
 Supported Platforms:
  - Android
+ - iOS (Arm64, X64, SimulatorArm64)
  - JS
  - JVM
  - LinuxArm64
  - LinuxX64
+ - MacosArm64
+ - MacosX64
+ - MingwX64
+ - WasmJs
  - WasmWasi
 
 Kotlin

--- a/arbor/build.gradle.kts
+++ b/arbor/build.gradle.kts
@@ -34,6 +34,9 @@ kotlin {
     }
     macosArm64()
     macosX64()
+    iosArm64()
+    iosX64()
+    iosSimulatorArm64()
     mingwX64()
     wasmJs {
         nodejs()

--- a/arbor/src/iosMain/kotlin/com/toxicbakery/logging/Seedling.kt
+++ b/arbor/src/iosMain/kotlin/com/toxicbakery/logging/Seedling.kt
@@ -1,0 +1,112 @@
+package com.toxicbakery.logging
+
+import com.toxicbakery.logging.Arbor.DEBUG
+import com.toxicbakery.logging.Arbor.ERROR
+import com.toxicbakery.logging.Arbor.INFO
+import com.toxicbakery.logging.Arbor.VERBOSE
+import com.toxicbakery.logging.Arbor.WARNING
+import com.toxicbakery.logging.Arbor.WTF
+import platform.Foundation.NSLog
+
+/**
+ * Basic logger that prints messages to the Apple unified logging system via [NSLog]. Messages are line printed in the
+ * format of `LEVEL/TAG: Message` with any [Throwable] stack trace appended.
+ *
+ * Positional arguments are interpolated into the message in order. As Kotlin/Native has no `String.format`, only the
+ * conversion position is honored; width, precision, and flags (e.g. the `5.2` in `%5.2f`) are ignored and the argument
+ * is inserted via its `toString()`.
+ *
+ * ```
+ * Arbor.sow(Seedling())
+ * ```
+ */
+public class Seedling internal constructor(
+    private val write: (String) -> Unit,
+) : ISeedling {
+
+    // Pass the message as an argument rather than the format string so `%` characters are never interpreted.
+    public constructor() : this(write = { message -> NSLog("%@", message) })
+
+    override val tag: String
+        get() = ""
+
+    override fun log(
+        level: Int,
+        tag: String,
+        msg: String,
+        throwable: Throwable?,
+        args: Array<out Any?>?
+    ) {
+        require(level in DEBUG..WTF)
+        val message = tag.withMessage(msg).interpolate(args)
+        if (message.isEmpty() && throwable == null) return
+        write("${level.levelLabel}$message".withThrowable(throwable))
+    }
+
+    private fun String.withMessage(msg: String): String =
+        if (isEmpty()) msg
+        else "$this: $msg"
+
+    private fun String.withThrowable(throwable: Throwable?): String =
+        if (throwable == null) this
+        else "$this\n${throwable.stackTraceToString()}"
+
+    /**
+     * Replace each `%[flags][width][.precision]conversion` token with the next argument's string representation,
+     * consuming arguments in order. `%%` yields a literal `%`. Mirrors the JVM seedling: when [args] is null or empty
+     * the receiver is returned untouched, and any specifier left without an argument is emitted verbatim.
+     */
+    private fun String.interpolate(args: Array<out Any?>?): String {
+        if (args.isNullOrEmpty()) return this
+        val result = StringBuilder(length)
+        var argIndex = 0
+        var index = 0
+        while (index < length) {
+            val char = this[index]
+            if (char != '%') {
+                result.append(char)
+                index++
+                continue
+            }
+            // Advance past the specifier's flags/width/precision to find the conversion character.
+            var end = index + 1
+            while (end < length && this[end] in FORMAT_PREFIX) end++
+            when {
+                end >= length -> {
+                    result.append(substring(index))
+                    index = length
+                }
+                this[end] == '%' -> {
+                    result.append('%')
+                    index = end + 1
+                }
+                argIndex < args.size -> {
+                    result.append(args[argIndex++].toString())
+                    index = end + 1
+                }
+                else -> {
+                    result.append(substring(index, end + 1))
+                    index = end + 1
+                }
+            }
+        }
+        return result.toString()
+    }
+
+    private val Int.levelLabel: String
+        get() = when (this) {
+            DEBUG -> "D/"
+            VERBOSE -> "V/"
+            INFO -> "I/"
+            WARNING -> "W/"
+            ERROR -> "E/"
+            WTF -> "F/"
+            else -> ""
+        }
+
+    private companion object {
+        // Flag, width, and precision characters that may appear between `%` and the conversion character.
+        private const val FORMAT_PREFIX = "0123456789.-+ #,("
+    }
+
+}

--- a/arbor/src/iosTest/kotlin/com/toxicbakery/logging/SeedlingTest.kt
+++ b/arbor/src/iosTest/kotlin/com/toxicbakery/logging/SeedlingTest.kt
@@ -1,0 +1,95 @@
+package com.toxicbakery.logging
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SeedlingTest {
+
+    private val output = mutableListOf<String>()
+    private val seedling: ISeedling = Seedling { line -> output.add(line) }
+
+    @BeforeTest
+    fun setup() {
+        Arbor.sow(seedling)
+    }
+
+    @AfterTest
+    fun teardown() {
+        Arbor.reset()
+    }
+
+    @Test
+    fun log() {
+        Arbor.d("Hello, World")
+        assertEquals(listOf("D/Hello, World"), output)
+    }
+
+    @Test
+    fun log_error() {
+        Arbor.e("Hello, World")
+        assertEquals(listOf("E/Hello, World"), output)
+    }
+
+    @Test
+    fun log_allLevels() {
+        Arbor.v("v")
+        Arbor.i("i")
+        Arbor.w("w")
+        Arbor.wtf("wtf")
+        assertEquals(listOf("V/v", "I/i", "W/w", "F/wtf"), output)
+    }
+
+    @Test
+    fun log_withTag() {
+        Arbor.tag("tag").d("Hello, World")
+        assertEquals(listOf("D/tag: Hello, World"), output)
+    }
+
+    @Test
+    fun log_withArgs() {
+        Arbor.d("Hello, %s", "World")
+        assertEquals(listOf("D/Hello, World"), output)
+    }
+
+    @Test
+    fun log_withMultipleArgs() {
+        Arbor.d("%s and %s", "a", "b")
+        assertEquals(listOf("D/a and b"), output)
+    }
+
+    @Test
+    fun log_withEmptyArgs() {
+        @Suppress("RemoveRedundantSpreadOperator")
+        Arbor.d("Hello, %s", *emptyArray<Any?>())
+        assertEquals(listOf("D/Hello, %s"), output)
+    }
+
+    @Test
+    fun log_withEscapedPercent() {
+        Arbor.d("100%% done", "ignored")
+        assertEquals(listOf("D/100% done"), output)
+    }
+
+    @Test
+    fun log_withException() {
+        seedling.log(Arbor.DEBUG, "tag", "msg", RuntimeException("boom"))
+        assertEquals(1, output.size)
+        assertTrue(output.first().startsWith("D/tag: msg\n"))
+    }
+
+    @Test
+    fun directLog_nullException() {
+        seedling.log(Arbor.DEBUG, "tag", "msg", null)
+        assertEquals(listOf("D/tag: msg"), output)
+    }
+
+    @Test
+    fun directLog_emptyMessageSkipped() {
+        seedling.log(level = Arbor.DEBUG, msg = "")
+        assertTrue(output.isEmpty())
+    }
+
+}


### PR DESCRIPTION
## Summary
- Add `iosArm64`, `iosX64`, and `iosSimulatorArm64` targets to the `arbor` module.
- Add an `NSLog`-backed `Seedling` for iOS: formats output as `LEVEL/TAG: Message`, appends `Throwable` stack traces, and interpolates positional args. Kotlin/Native has no `String.format`, so a small positional formatter mirrors the JVM seedling's behavior (`%s`, `%d`, `%%`, empty-args passthrough); width/precision/flags are parsed-and-skipped and the arg is inserted via `toString()`.
- Cover the seedling with an `iosTest` `SeedlingTest` using an injectable writer to capture output.
- Run the iOS simulator tests in CI on a macOS executor, gating the Linux build/publish job.
- Update the README platform list and add an iOS usage example.

## CI topology
Publishing stays on the cheap Linux agent — it cross-compiles and publishes the Apple klibs fine (verified locally: a full `arbor-iosarm64` `.klib` + `.module` + `.pom` + sources/javadoc). macOS is used **only** to execute the iOS simulator tests, since that's the one thing Linux can't do. The `build` (publish) job now `requires` the macOS `ios-test` job, so a red iOS suite blocks publishing.

## Verification
- All three iOS targets compile `main` + `test` source sets to klibs on Linux (`compileKotlinIos*` / `compileTestKotlinIos*`).
- The positional formatter was runtime-verified across 11 cases via the JVM harness (single/multiple args, `%%`, `%d`, flag/width/precision, out-of-args, trailing `%`, null arg, empty/null passthrough).
- `.circleci/config.yml` validated: `build.requires == [ios-test]`, both jobs carry the tag filter.

## Not verifiable on Linux
Linking and **running** the iOS test binaries needs Xcode/macOS, so the first run on the new `ios-test` job is where the simulator boot + test execution gets exercised. The macOS `resource_class` (`m4pro.medium`) and `xcode` version may need adjusting to match the CircleCI plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)