### PR TITLE
Add iOS sample app and fix iOS Seedling NSLog crash

### DIFF
--- a/arbor/build.gradle.kts
+++ b/arbor/build.gradle.kts
@@ -34,9 +34,19 @@ kotlin {
     }
     macosArm64()
     macosX64()
-    iosArm64()
-    iosX64()
-    iosSimulatorArm64()
+    // Expose a static framework named "ArborKit" so the examples/ios sample can link Arbor from Xcode via
+    // the :arbor:embedAndSignAppleFrameworkForXcode task. The name differs from the "Arbor" class to avoid a
+    // module/type collision in Swift. Framework binaries are not published to Maven; only klibs are.
+    listOf(
+        iosArm64(),
+        iosX64(),
+        iosSimulatorArm64(),
+    ).forEach { iosTarget ->
+        iosTarget.binaries.framework {
+            baseName = "ArborKit"
+            isStatic = true
+        }
+    }
     mingwX64()
     wasmJs {
         nodejs()

--- a/arbor/src/iosMain/kotlin/com/toxicbakery/logging/Seedling.kt
+++ b/arbor/src/iosMain/kotlin/com/toxicbakery/logging/Seedling.kt
@@ -24,8 +24,11 @@ public class Seedling internal constructor(
     private val write: (String) -> Unit,
 ) : ISeedling {
 
-    // Pass the message as an argument rather than the format string so `%` characters are never interpreted.
-    public constructor() : this(write = { message -> NSLog("%@", message) })
+    // Log via NSLog without its variadic argument list: Kotlin/Native does not marshal a Kotlin String into a
+    // C variadic call as an Obj-C object, so `NSLog("%@", message)` reads the string bytes as a pointer and
+    // crashes. Instead pass the message as the (non-variadic, properly bridged) format string with every `%`
+    // escaped to `%%`, so no conversion specifier is ever interpreted.
+    public constructor() : this(write = { message -> NSLog(message.replace("%", "%%")) })
 
     override val tag: String
         get() = ""

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,1 +1,8 @@
 # Examples
+
+Sample projects demonstrating how to use Arbor on each platform.
+
+- [`android`](android) — an Android app using the `LogCatSeedling` and JVM `Seedling`.
+- [`ios`](ios) — a SwiftUI app using the iOS `Seedling` (NSLog). See its [README](ios/README.md) for the
+  Xcode/Gradle framework integration.
+- [`java`](java) — a plain JVM application using the JVM `Seedling`.

--- a/examples/ios/.gitignore
+++ b/examples/ios/.gitignore
@@ -1,0 +1,12 @@
+# Xcode build output
+build/
+DerivedData/
+
+# Xcode user-specific state
+*.xcuserstate
+xcuserdata/
+*.xcscmblueprint
+*.xccheckout
+
+# macOS
+.DS_Store

--- a/examples/ios/ArborSample.xcodeproj/project.pbxproj
+++ b/examples/ios/ArborSample.xcodeproj/project.pbxproj
@@ -1,0 +1,360 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		000000000000000000000009 /* ArborSampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000007 /* ArborSampleApp.swift */; };
+		00000000000000000000000A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000008 /* ContentView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		000000000000000000000003 /* ArborSample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ArborSample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000000000000000000007 /* ArborSampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArborSampleApp.swift; sourceTree = "<group>"; };
+		000000000000000000000008 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		00000000000000000000000C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		000000000000000000000004 = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000005 /* ArborSample */,
+				000000000000000000000006 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		000000000000000000000005 /* ArborSample */ = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000007 /* ArborSampleApp.swift */,
+				000000000000000000000008 /* ContentView.swift */,
+			);
+			path = ArborSample;
+			sourceTree = "<group>";
+		};
+		000000000000000000000006 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000003 /* ArborSample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		000000000000000000000002 /* ArborSample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 000000000000000000000010 /* Build configuration list for PBXNativeTarget "ArborSample" */;
+			buildPhases = (
+				00000000000000000000000E /* Build Arbor framework */,
+				00000000000000000000000B /* Sources */,
+				00000000000000000000000C /* Frameworks */,
+				00000000000000000000000D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ArborSample;
+			productName = ArborSample;
+			productReference = 000000000000000000000003 /* ArborSample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		000000000000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					000000000000000000000002 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = 00000000000000000000000F /* Build configuration list for PBXProject "ArborSample" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 000000000000000000000004;
+			productRefGroup = 000000000000000000000006 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				000000000000000000000002 /* ArborSample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		00000000000000000000000D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		00000000000000000000000E /* Build Arbor framework */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build Arbor framework";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Build, embed, and sign the Arbor Kotlin/Native framework for the active Xcode configuration.\ncd \"$SRCROOT/../..\"\n./gradlew :arbor:embedAndSignAppleFrameworkForXcode\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		00000000000000000000000B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				000000000000000000000009 /* ArborSampleApp.swift in Sources */,
+				00000000000000000000000A /* ContentView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		000000000000000000000011 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		000000000000000000000012 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		000000000000000000000013 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../arbor/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					ArborKit,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.arborsample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		000000000000000000000014 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../arbor/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					ArborKit,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.arborsample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		00000000000000000000000F /* Build configuration list for PBXProject "ArborSample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				000000000000000000000011 /* Debug */,
+				000000000000000000000012 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		000000000000000000000010 /* Build configuration list for PBXNativeTarget "ArborSample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				000000000000000000000013 /* Debug */,
+				000000000000000000000014 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 000000000000000000000001 /* Project object */;
+}

--- a/examples/ios/ArborSample.xcodeproj/xcshareddata/xcschemes/ArborSample.xcscheme
+++ b/examples/ios/ArborSample.xcodeproj/xcshareddata/xcschemes/ArborSample.xcscheme
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "000000000000000000000002"
+               BuildableName = "ArborSample.app"
+               BlueprintName = "ArborSample"
+               ReferencedContainer = "container:ArborSample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "000000000000000000000002"
+            BuildableName = "ArborSample.app"
+            BlueprintName = "ArborSample"
+            ReferencedContainer = "container:ArborSample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "000000000000000000000002"
+            BuildableName = "ArborSample.app"
+            BlueprintName = "ArborSample"
+            ReferencedContainer = "container:ArborSample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/ios/ArborSample/ArborSampleApp.swift
+++ b/examples/ios/ArborSample/ArborSampleApp.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+import ArborKit
+
+@main
+struct ArborSampleApp: App {
+
+    init() {
+        // No seedling has been sown yet, so this log goes into the void. Always sow before logging.
+        Arbor.shared.d(msg_: "Log into the void! Make sure you sow a seedling before writing logs.")
+
+        // Sow the iOS Seedling. It writes to the Apple unified logging system via NSLog, so messages
+        // show up in the Xcode console and Console.app.
+        Arbor.shared.sow(seedling: Seedling())
+
+        ArborDemo.run()
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+
+/// A handful of calls exercising the Arbor API from Swift. Mirrors the Android sample's ArborApplication.
+enum ArborDemo {
+
+    static func run() {
+        // Plain messages. Note the `msg_:` label: Arbor also exposes a `msg:` overload that takes a
+        // `() -> String` closure, so the Kotlin/Native binding disambiguates the String overload with a
+        // trailing underscore.
+        Arbor.shared.d(msg_: "Hello from Swift")
+        Arbor.shared.tag(tag: "Sample").i(msg_: "Hello with a tag")
+        Arbor.shared.w(msg_: "Something worth a warning")
+
+        // Lazily evaluated message. The closure only runs when at least one seedling is sown.
+        Arbor.shared.v(msg: { "Verbose message built lazily" })
+
+        // Kotlin/Native has no String.format, so the iOS Seedling interpolates positional args itself.
+        let values: [NSString] = ["one", "two"]
+        let formatArgs = KotlinArray<AnyObject>(size: Int32(values.count)) { index in
+            values[Int(truncating: index)]
+        }
+        Arbor.shared.d(msg: "Formatting %s and %s", args: formatArgs)
+
+        // Logging a throwable appends its stack trace to the message.
+        Arbor.shared.e(
+            throwable: KotlinThrowable(message: "Sample failure"),
+            msg_: "Something went wrong"
+        )
+    }
+
+}

--- a/examples/ios/ArborSample/ContentView.swift
+++ b/examples/ios/ArborSample/ContentView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+import ArborKit
+
+struct ContentView: View {
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "leaf.fill")
+                .imageScale(.large)
+                .font(.system(size: 48))
+                .foregroundStyle(.green)
+            Text("Arbor iOS Sample")
+                .font(.headline)
+            Text("Tap to write logs through Arbor's iOS Seedling (NSLog).\nWatch the Xcode console or Console.app.")
+                .font(.footnote)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+            Button("Write logs") {
+                ArborDemo.run()
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -1,0 +1,101 @@
+# Arbor iOS Sample
+
+A minimal SwiftUI app that consumes the Arbor Kotlin Multiplatform library from Swift and logs through
+Arbor's iOS `Seedling`, which writes to the Apple unified logging system via `NSLog`.
+
+It is the iOS counterpart to [`examples/android`](../android). Because an iOS app is an Xcode project rather
+than a Gradle module, this sample is **not** part of `settings.gradle.kts`; instead it links the `:arbor`
+module's framework using the standard Kotlin/Native direct-integration approach.
+
+## What it shows
+
+`ArborSampleApp` sows a `Seedling()` and then exercises the API (see `ArborDemo.run()`):
+
+```swift
+import ArborKit
+
+Arbor.shared.sow(seedling: Seedling())
+Arbor.shared.d(msg_: "Hello from Swift")                 // plain message
+Arbor.shared.tag(tag: "Sample").i(msg_: "Hello with a tag")
+Arbor.shared.v(msg: { "Verbose message built lazily" })   // lazy () -> String overload
+Arbor.shared.d(msg: "Formatting %s and %s", args: /* KotlinArray */)
+Arbor.shared.e(throwable: KotlinThrowable(message: "..."), msg_: "Something went wrong")
+```
+
+> Note the `msg_:` argument label on the String overloads: Arbor also exposes a `msg:` overload that takes a
+> `() -> String` closure, so the Kotlin/Native binding disambiguates the plain-String overload with a trailing
+> underscore.
+
+## How the framework is wired up
+
+The `:arbor` module declares static iOS frameworks named `ArborKit` (see `arbor/build.gradle.kts`). The Xcode
+project pulls them in with two pieces:
+
+1. A **Run Script** build phase (`Build Arbor framework`) that runs before compilation:
+
+   ```sh
+   cd "$SRCROOT/../.."
+   ./gradlew :arbor:embedAndSignAppleFrameworkForXcode
+   ```
+
+   The Gradle task reads Xcode's environment (`CONFIGURATION`, `SDK_NAME`, `ARCHS`, …) and assembles the right
+   framework under `arbor/build/xcode-frameworks/<config>/<sdk>/`.
+
+2. Build settings that point at that output and link it:
+
+   - `FRAMEWORK_SEARCH_PATHS = $(SRCROOT)/../../arbor/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)`
+   - `OTHER_LDFLAGS = -framework ArborKit`
+   - `ENABLE_USER_SCRIPT_SANDBOXING = NO` — required so the Gradle script may write outside the Xcode project
+     directory.
+
+## Prerequisites
+
+- Xcode (with an iOS simulator runtime installed)
+- A JDK on `PATH` (used by `./gradlew`)
+
+## Run in Xcode
+
+```sh
+open examples/ios/ArborSample.xcodeproj
+```
+
+Select the `ArborSample` scheme and an iOS Simulator, then Run. The first build invokes Gradle to compile the
+Kotlin/Native framework, so it takes a little longer than subsequent builds.
+
+## Build / run from the command line
+
+```sh
+# Build for a simulator
+xcodebuild -project examples/ios/ArborSample.xcodeproj \
+  -scheme ArborSample \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  build
+
+# Install and launch on the booted simulator
+APP=$(xcodebuild -project examples/ios/ArborSample.xcodeproj -scheme ArborSample -showBuildSettings \
+  | awk '/ BUILT_PRODUCTS_DIR /{d=$3}/ FULL_PRODUCT_NAME /{n=$3}END{print d"/"n}')
+xcrun simctl install booted "$APP"
+xcrun simctl launch booted com.example.arborsample
+```
+
+## Viewing the logs
+
+`NSLog` writes to the unified logging system, so the messages show up in **Console.app** and in the Xcode
+console while debugging. From the command line they are emitted at info/debug level, so include those flags:
+
+```sh
+xcrun simctl spawn booted log show --last 1m --info --debug \
+  --predicate 'process == "ArborSample"' | grep -E '^[DVIWEF]/'
+```
+
+Expected output:
+
+```
+D/Hello from Swift
+I/Sample: Hello with a tag
+W/Something worth a warning
+V/Verbose message built lazily
+D/Formatting one and two
+E/Something went wrong
+...stack trace...
+```


### PR DESCRIPTION
## Summary

Adds an iOS sample app (`examples/ios`) — the iOS counterpart to `examples/android` — and fixes a runtime crash in the iOS `Seedling` that the sample surfaced.

- **`examples/ios`** — a minimal SwiftUI app that sows `Seedling()` and exercises the Arbor API from Swift (`Arbor.shared.d/i/w/v/e`, tags, lazy `() -> String` messages, `%s` interpolation, and a throwable). It consumes the `:arbor` Kotlin/Native framework via the standard direct-integration approach: an `embedAndSignAppleFrameworkForXcode` run-script phase plus framework search paths / linker flags. Because an iOS app is an Xcode project rather than a Gradle module, it is intentionally **not** added to `settings.gradle.kts`.
- **`arbor/build.gradle.kts`** — the three iOS targets now emit a static framework named `ArborKit`. Framework binaries are not published to Maven (only klibs are), so the published artifact is unchanged.
- **`arbor/src/iosMain/.../Seedling.kt`** — bug fix (below).

## The bug

The default `Seedling()` logged via `NSLog("%@", message)`. Kotlin/Native does not marshal a Kotlin `String` into a C **variadic** call as an Obj-C `id`, so CoreFoundation interprets the string's bytes as a pointer and the app crashes with `EXC_BAD_ACCESS` on the very first log:

```
NSLog -> _NSLogv -> __CFStringAppendFormatCore -> _NSDescriptionWithStringProxyFunc
      -> objc_opt_respondsToSelector  (EXC_BAD_ACCESS)
  <- Seedling.write { NSLog("%@", message) }  <- Seedling.log <- Branch.d <- Arbor.d
```

Fix — avoid the variadic call entirely by passing the message as the (non-variadic, properly bridged) format string with every `%` escaped:

```kotlin
// before:  NSLog("%@", message)
// after:   NSLog(message.replace("%", "%%"))
```

**Why CI was green anyway:** `SeedlingTest` injects a fake writer (`Seedling { line -> output.add(line) }`) and never runs the real `NSLog` path, so the crashing default constructor was untested. All existing tests still pass after the fix.

## Verification

- `xcodebuild -scheme ArborSample -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` → **BUILD SUCCEEDED**
- Installed + launched on the simulator (no crash); unified-log output:
  ```
  D/Hello from Swift
  I/Sample: Hello with a tag
  W/Something worth a warning
  V/Verbose message built lazily
  D/Formatting one and two
  E/Something went wrong (+ stack trace)
  ```
- `./gradlew :arbor:iosSimulatorArm64Test` → 11/11 `SeedlingTest` pass.
